### PR TITLE
set github credentials before deployment

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -26,4 +26,5 @@ jobs:
         with:
           node-version: '12.16.2'
       - run: yarn install
+      - run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
       - run: yarn deploy


### PR DESCRIPTION
This pr adds git credentials before performing a github pages deployment on release. we will authenticate as "github" when performing deployment.