### PR TITLE
New cookies design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gfw-components",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "main": "lib/index.js",
   "scripts": {
     "start": "styleguidist server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gfw-components",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "main": "lib/index.js",
   "scripts": {
     "start": "styleguidist server",

--- a/src/components/button/button.md
+++ b/src/components/button/button.md
@@ -13,6 +13,10 @@ Generic `<button />` with style fixes for IE>=11 and a variety of render props, 
 <br />
 <Button light>Light</Button>
 <br />
+<Button lightGrey>Light Grey</Button>
+<br />
+<Button lightGreyAlternate>Light Grey alternate</Button>
+<br />
 <Button dark>Dark</Button>
 <br />
 <Button clear>Clear</Button>

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -27,6 +27,10 @@ class Button extends PureComponent {
     round: PropTypes.bool,
     /** light colors */
     light: PropTypes.bool,
+    /** gray colors */
+    lightGrey: PropTypes.bool,
+    /** gray colors */
+    lightGreyAlternate: PropTypes.bool,
     /** dark colors */
     dark: PropTypes.bool,
     /** no colors */

--- a/src/components/button/styles.js
+++ b/src/components/button/styles.js
@@ -120,6 +120,28 @@ export const ButtonParent = styled.button`
     }
   `}
 
+  ${({ lightGrey }) =>
+    lightGrey &&
+    `
+    background-color: ${theme.colors.lightGrey};
+
+    &:hover {
+      background-color: ${theme.colors.darkGrey};
+    }
+  `}
+
+  ${({ lightGreyAlternate }) =>
+    lightGreyAlternate &&
+    `
+    color: ${theme.colors.darkestGrey};
+    background-color: ${theme.colors.lightGrey};
+
+    &:hover {
+      color: ${theme.colors.white};
+      background-color: ${theme.colors.darkGrey};
+    }
+  `}
+
   ${({ dark }) =>
     dark &&
     `

--- a/src/components/cookies-banner/index.js
+++ b/src/components/cookies-banner/index.js
@@ -10,10 +10,9 @@ import { CookiesWrapper } from './styles';
 
 const CookiesBanner = ({ onAccept }) => (
   <CookiesWrapper>
-    <Row>
-      <Column width={[0, 1 / 12]} />
-      <Column width={[1, 2 / 3]}>
-        <P className="cookies-text">
+    <Row className="cookies-row">
+      <Column className="cookies-text">
+        <P>
           This website uses cookies to provide you with an improved user
           experience. By continuing to browse this site, you consent to the use
           of cookies and similar technologies. Please visit our
@@ -26,13 +25,8 @@ const CookiesBanner = ({ onAccept }) => (
           for further details.
         </P>
       </Column>
-      <Column width={[1, 1 / 6]} className="cookies-button">
-        <Button
-          className="cookies-btn"
-          color="grey"
-          size="small"
-          onClick={onAccept}
-        >
+      <Column className="cookies-button">
+        <Button lightGreyAlternate onClick={onAccept}>
           I agree
         </Button>
       </Column>

--- a/src/components/cookies-banner/index.js
+++ b/src/components/cookies-banner/index.js
@@ -16,10 +16,9 @@ const CookiesBanner = ({ onAccept }) => (
           This website uses cookies to provide you with an improved user
           experience. By continuing to browse this site, you consent to the use
           of cookies and similar technologies. Please visit our
+          {' '}
           <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">
-            {' '}
             privacy policy
-            {' '}
           </a>
           {' '}
           for further details.

--- a/src/components/cookies-banner/styles.js
+++ b/src/components/cookies-banner/styles.js
@@ -2,23 +2,37 @@ import theme from 'styles/theme';
 import styled from '@emotion/styled';
 
 export const CookiesWrapper = styled.div`
+  display: flex;
   width: 100%;
   background-color: rgba(51, 51, 51, 0.9);
   padding: 20px 0;
 
+  .cookies-row {
+    display: flex;
+    flex-direction: column;
+
+    ${theme.mediaQueries.small} {
+      flex-direction: row;
+    }
+  }
+
   .cookies-text {
-    color: ${theme.colors.white};
-    font-size: 12px;
-    line-height: 18px;
-    margin-bottom: 20px;
+    flex: 1;
+
+    p {
+      color: ${theme.colors.white};
+      font-size: 12px;
+      line-height: 18px;
+      margin-bottom: 20px;
+
+      ${theme.mediaQueries.small} {
+        margin-bottom: 0;
+      }
+    }
 
     a {
       font-size: 12px;
       line-height: 18px;
-    }
-
-    ${theme.mediaQueries.small} {
-      margin-bottom: 0;
     }
   }
 
@@ -26,19 +40,10 @@ export const CookiesWrapper = styled.div`
     display: flex;
     align-items: center;
     max-width: 220px;
+    width: auto;
 
     ${theme.mediaQueries.small} {
       max-width: auto;
-    }
-
-    .cookies-btn {
-      color: #fff;
-      border-color: transparent;
-      background: ${theme.colors.darkGrey};
-      text-transform: uppercase;
-      font-size: 14px;
-      font-weight: 500;
-      width: 100%;
     }
   }
 `;


### PR DESCRIPTION
## Description

This PR updates the `CookiesBanner` component to better match the designs as described [in the design task](https://gfw.atlassian.net/browse/FLAG-127). 

**In this PR:**  
- Added two new button styles (**\*1**):
  _The original button was hardcoded in SCSS instead of using our button components_
  - `lightGrey`: Light grey button with white text  
    _Not actually used; however it was added to follow the existing button naming pattern where buttons with a colored background have dark text_  
  - `lightGreyAlternate`: Light grey button with dark text
    _This is the button used in the `CookiesBanner`._
- Tweaked the layout/styling of the `CookiesBanner` component (**\*2**)
  _to be compatible with the new positioning, which will be set in `gfw`, `gfw-blog`, `gfw-help center`_
- Bumped the package version

**Notes:**  
- I toyed with the idea of setting the positioning here in `gfw-components`, so that similar changes in the future could be made only in this repo, but ran into issues getting `styleguidist` to display it correctly. Failing to find a solution, I opted to go with the current implementation. 
- The styling for mobile is kept unchanged (with the exception of the new button design)

## Tracking 

[FLAG-484](https://gfw.atlassian.net/browse/FLAG-484)

## Screenshots

**Styleguidist**  
<img width="962" alt="Screenshot 2022-09-19 at 14 08 19" src="https://user-images.githubusercontent.com/6273795/191024520-64589b61-3f70-45de-84aa-b64cee9d98ad.png">


**\*1 - New button styles**
<img width="463" alt="new_buttons" src="https://user-images.githubusercontent.com/6273795/191008656-f5680c4e-925d-46b1-a3f3-7c3018029543.png">

**\*2 - Tweaked layout**  
<img width="639" alt="changes" src="https://user-images.githubusercontent.com/6273795/191008942-16df5eca-a91a-4e40-8002-6903b7ac01b8.png">

### Display when changes to the other repos are implemented

_(actual sizing varies by screen resolution, but the *"My GFW" will always be unobstructed*)_

<img width="1455" alt="Screenshot 2022-09-19 at 12 51 11" src="https://user-images.githubusercontent.com/6273795/191011087-ae8af73b-9011-48e9-a0e7-9ada56c4e7f4.png">

