### PR TITLE
Replace link to MapBuilder website in main menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gfw-components",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "main": "lib/index.js",
   "scripts": {
     "start": "styleguidist server",

--- a/src/components/header/config.js
+++ b/src/components/header/config.js
@@ -55,7 +55,7 @@ export default {
   moreLinks: [
     {
       label: 'Mapbuilder',
-      href: '/mapbuilder/',
+      extLink: 'https://mapbuilder.wri.org/',
       icon: mapbuilder,
     },
     {


### PR DESCRIPTION
## Description

This PR replaces the link to MapBuilder website in the header to the new website's link. 