### PR TITLE
chore(prop-types): Change propTypes to match its use and avoid console errors.

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -52,7 +52,7 @@ class Header extends PureComponent {
     /** path to custom logo */
     customLogo: PropTypes.string,
     /** allows to pass "theme" down to the header */
-    theme: PropTypes.bool,
+    theme: PropTypes.string,
     /** makes the header "slimmer" */
     slim: PropTypes.bool,
   };


### PR DESCRIPTION
## Overview
Inside `components/header/index` the "theme" props was set as bool but implemented as string. It was causing some errors on console.

## Demo
![Screenshot 2023-02-16 at 14 59 32](https://user-images.githubusercontent.com/23243868/219449303-f026ef34-fa23-410a-a3d7-3e9cb9c5f69f.png)

