### PR TITLE
chore(migrate-package): moving gfw-components to WRI org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gfw-components",
+  "name": "@worldresources/gfw-components",
   "version": "1.8.11",
   "main": "lib/index.js",
   "scripts": {
@@ -10,6 +10,9 @@
     "compile:static": "BUILD_MODE=static NODE_ENV=production webpack --progress",
     "deploy": "yarn build && gh-pages -d styleguide",
     "lint": "eslint src/** -c .eslintrc.json --ext js,jsx --no-error-on-unmatched-pattern"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldresources/gfw-components",
-  "version": "1.8.11",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "scripts": {
     "start": "styleguidist server",


### PR DESCRIPTION
## Overview

We have been migrating repositories and packages to WRI organization. 
I'm migrating this one as its relative package on NPM. 

https://www.npmjs.com/package/gfw-components