### PR TITLE
chore: add github creds to `deploy styleguidist`

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -28,3 +28,5 @@ jobs:
       - run: yarn install
       - run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
       - run: yarn deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# fix: pass GH_TOKEN to yarn deploy for gh-pages authentication

## Summary

The `Deploy styleguidist` job in `on_release.yml` has been silently failing on every release
since the workflow was created in November 2020. This PR fixes it with a one-line change.

## Background

The workflow has two jobs:

| Job | Status | Purpose |
|---|---|---|
| `publish` | ✅ Always succeeded | Publishes the npm package using `NPM_TOKEN` |
| `Deploy styleguidist` | ❌ Always failed | Builds and pushes docs to `components.globalforestwatch.org` |

The site at `components.globalforestwatch.org` has been kept up-to-date manually — team
members have been running `yarn deploy` locally after each release for ~6 years.

## Root Cause

`yarn deploy` runs:
```
yarn build && gh-pages -d styleguide
```

The `gh-pages` npm package builds the styleguidist output and then does a `git push` to the
`gh-pages` branch. That push requires GitHub authentication.

`actions/checkout@v1` provides credentials **only for the initial fetch** via a per-command
`-c http.extraheader` flag — it does not write credentials to the global git config. By the
time `gh-pages` runs its push, there are no credentials available, so git falls back to
prompting interactively, which fails in CI:

```
fatal: could not read Username for 'https://github.com': No such device or address
error Command failed with exit code 1.
```

A previous attempt to fix this (commit `5b1e5b7`, Nov 4 2020, "set github credentials before
deployment") added:
```yaml
- run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
```

This sets the git commit **identity** (author name/email) — not the **authentication token**
needed to push. The push still failed.

### Evidence the deploy has never worked

Every commit ever pushed to the `gh-pages` branch uses personal developer email addresses
(e.g. `willian.batista.viana@gmail.com`). If the workflow had ever succeeded, the commit
author email would be `<GITHUB_ACTOR>@users.noreply.github.com`, as set by the workflow's
own git config step. That pattern has never appeared in the branch history.

## The Fix

The `gh-pages` npm package natively supports a `GH_TOKEN` environment variable for
authentication. `GITHUB_TOKEN` is automatically provided by GitHub Actions and already has
`Contents: write` permission on this repo — no new secrets need to be created.

```yaml
# Before
- run: yarn deploy

# After
- run: yarn deploy
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

## Impact

- **No risk of breaking the live site** — the workflow builds from the release tag, same
  source as the manual deploys. The next release will just automate what the team has been
  doing by hand.
- **No new secrets required** — `GITHUB_TOKEN` is built-in to every workflow run.
- The `publish` job is unaffected.

---

## How the workflow works (after this fix)

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Runner as Actions Runner
    participant NPM as npm registry
    participant Pages as gh-pages branch<br/>(components.globalforestwatch.org)

    Dev->>GH: Publish release (e.g. 3.5.20)
    GH->>Runner: Trigger on_release.yml

    rect rgb(220, 240, 220)
        note over Runner: Job: publish
        Runner->>Runner: actions/checkout@v1
        Runner->>Runner: actions/setup-node@v1 (Node 12)
        Runner->>Runner: yarn install
        Runner->>Runner: yarn compile
        Runner->>NPM: npm-publish (using NPM_TOKEN)
        NPM-->>Runner: ✅ Package published
    end

    rect rgb(220, 230, 245)
        note over Runner: Job: deploy (needs: publish)
        Runner->>Runner: actions/checkout@v1
        Runner->>Runner: actions/setup-node@v1 (Node 12)
        Runner->>Runner: yarn install
        Runner->>Runner: git config user.email / user.name
        Runner->>Runner: yarn build (styleguidist build → ./styleguide/)
        note over Runner: GH_TOKEN=secrets.GITHUB_TOKEN<br/>passed to gh-pages push
        Runner->>Pages: gh-pages -d styleguide<br/>(git push via GH_TOKEN)
        Pages-->>Runner: ✅ Docs deployed
    end

    GH->>Dev: ✅ Both jobs succeed
```
