### PR TITLE
chore: add github creds to `deploy styleguidist` for v2.x gh-pages action

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -27,6 +27,5 @@ jobs:
           node-version: '12.16.2'
       - run: yarn install
       - run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
+      - run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
       - run: yarn deploy
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# fix: embed GITHUB_TOKEN in remote URL for gh-pages authentication

## Summary

The `Deploy styleguidist` job in `on_release.yml` has been silently failing on every release
since the workflow was created in November 2020. This PR fixes it by rewriting the git remote
URL to include `GITHUB_TOKEN` before `gh-pages` runs its push.

## Background

The workflow has two jobs:

| Job | Status | Purpose |
|---|---|---|
| `publish` | ✅ Always succeeded | Publishes the npm package using `NPM_TOKEN` |
| `Deploy styleguidist` | ❌ Always failed | Builds and pushes docs to `components.globalforestwatch.org` |

The site at `components.globalforestwatch.org` has been kept up-to-date manually — team
members have been running `yarn deploy` locally after each release for ~6 years.

## Root Cause

`yarn deploy` runs:
```
yarn build && gh-pages -d styleguide
```

The `gh-pages` npm package builds the styleguidist output and then does a `git push` to the
`gh-pages` branch. That push requires GitHub authentication.

`actions/checkout@v1` provides credentials **only for the initial fetch** via a per-command
`-c http.extraheader` flag — it does not write credentials to the global git config. By the
time `gh-pages` runs its push, there are no credentials available, so git falls back to
prompting interactively, which fails in CI:

```
fatal: could not read Username for 'https://github.com': No such device or address
error Command failed with exit code 1.
```

A previous attempt to fix this (commit `5b1e5b7`, Nov 4 2020, "set github credentials before
deployment") added:
```yaml
- run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
```

This sets the git commit **identity** (author name/email) — not the **authentication token**
needed to push. The push still failed.

### Evidence the deploy has never worked

Every commit ever pushed to the `gh-pages` branch uses personal developer email addresses
(e.g. `willian.batista.viana@gmail.com`). If the workflow had ever succeeded, the commit
author email would be `<GITHUB_ACTOR>@users.noreply.github.com`, as set by the workflow's
own git config step. That pattern has never appeared in the branch history.

## The Fix

### First attempt (incorrect)

An initial attempt passed `GH_TOKEN` as an environment variable to `yarn deploy`:

```yaml
- run: yarn deploy
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

This still failed with the same error. The `GH_TOKEN` environment variable is only read
natively by **`gh-pages` v3+**. This repo is pinned to `gh-pages@2.2.0`, which ignores it.

The [gh-pages README](https://github.com/tschaub/gh-pages/blob/main/readme.md) documents the
v2.x approach to authentication in its `silent` option example:

> ```js
> ghpages.publish('dist', {
>   repo: 'https://' + process.env.GH_TOKEN + '@github.com/user/private-repo.git',
>   silent: true
> });
> ```

`gh-pages` reads the `origin` remote URL from the current working directory and uses it as
the push target. The token must be embedded **in the URL itself**.

### Actual fix

Rewrite the remote URL to include the token before `gh-pages` runs:

```yaml
# Before
- run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
- run: yarn deploy

# After
- run: git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && git config --global user.name "$GITHUB_ACTOR"
- run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
- run: yarn deploy
```

`x-access-token` is Git's standard credential username for GitHub installation tokens —
the same format used internally by [`actions/checkout`](https://github.com/actions/checkout/blob/main/src/git-auth-helper.ts).
`GITHUB_TOKEN` is automatically provided by GitHub Actions, already has `Contents: write`
permission on this repo, and is masked in logs — no new secrets need to be created.

## Impact

- **No risk of breaking the live site** — the workflow builds from the release tag, same
  source as the manual deploys. The next release will just automate what the team has been
  doing by hand.
- **No new secrets required** — `GITHUB_TOKEN` is built-in to every workflow run.
- The `publish` job is unaffected.

---

## How the workflow works (after this fix)

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Runner as Actions Runner
    participant NPM as npm registry
    participant Pages as gh-pages branch<br/>(components.globalforestwatch.org)

    Dev->>GH: Publish release (e.g. 3.5.20)
    GH->>Runner: Trigger on_release.yml

    rect rgb(220, 240, 220)
        note over Runner: Job: publish
        Runner->>Runner: actions/checkout@v1
        Runner->>Runner: actions/setup-node@v1 (Node 12)
        Runner->>Runner: yarn install
        Runner->>Runner: yarn compile
        Runner->>NPM: npm-publish (using NPM_TOKEN)
        NPM-->>Runner: ✅ Package published
    end

    rect rgb(220, 230, 245)
        note over Runner: Job: deploy (needs: publish)
        Runner->>Runner: actions/checkout@v1
        Runner->>Runner: actions/setup-node@v1 (Node 12)
        Runner->>Runner: yarn install
        Runner->>Runner: git config user.email / user.name
        Runner->>Runner: git remote set-url origin<br/>https://x-access-token:GITHUB_TOKEN@github.com/wri/gfw-components.git
        Runner->>Runner: yarn build (styleguidist build → ./styleguide/)
        note over Runner: gh-pages reads origin URL,<br/>token already embedded
        Runner->>Pages: gh-pages -d styleguide<br/>(git push via token in remote URL)
        Pages-->>Runner: ✅ Docs deployed
    end

    GH->>Dev: ✅ Both jobs succeed
```
