### PR TITLE
Switch domain from globalforestwatch.org to globalnaturewatch.org - #108

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldresources/gfw-components",
-  "version": "3.5.21",
+  "version": "3.5.22",
   "main": "lib/index.js",
   "scripts": {
     "start": "styleguidist server",

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const breakpoints = {
 
 // Once globalnaturewatch.org is serving the app, this is the only line that
 // needs to change for every *.globalforestwatch.org constant below.
-export const GFW_DOMAIN = 'globalforestwatch.org';
+export const GFW_DOMAIN = 'globalnaturewatch.org';
 
 export const APP_URL = `https://www.${GFW_DOMAIN}`;
 export const GFW_API = 'https://api.resourcewatch.org';


### PR DESCRIPTION
globalforestwatch.org -> globalnaturewatch.org for root domain
upgrade package version to 3.5.22