### PR TITLE
[PZB-1179] Replace Flagship "Contact Us" Form with Zendesk Form Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldresources/gfw-components",
-  "version": "3.5.22",
+  "version": "3.5.23",
   "main": "lib/index.js",
   "scripts": {
     "start": "styleguidist server",

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -23,7 +23,11 @@ const images = require.context('assets/logos/partners', true);
 
 class Footer extends PureComponent {
   static propTypes = {
-    /** handle openning the contact us modal */
+    /** the contact modal has been removed
+     *  the prop openContactUsModal was left here for rollback purposes
+     */
+
+    // eslint-disable-next-line react/no-unused-prop-types
     openContactUsModal: PropTypes.func,
     className: PropTypes.string,
     handleCookiePreferencesClick: PropTypes.func,
@@ -76,7 +80,6 @@ class Footer extends PureComponent {
 
   render() {
     const {
-      openContactUsModal,
       className,
       handleCookiePreferencesClick = () => [],
       showCookiePreferencesLink = false,
@@ -122,9 +125,13 @@ class Footer extends PureComponent {
             </Column>
             <Column>
               <div className="footer-contact-us">
-                <button className="contact-btn" onClick={openContactUsModal}>
-                  CONTACT US
-                </button>
+                <a
+                  href="https://globalnaturewatch.zendesk.com/hc/en-us/requests/new"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <button className="contact-btn">CONTACT US</button>
+                </a>
                 <a
                   href={`${APP_URL}/subscribe`}
                   target="_blank"

--- a/src/components/header/config.js
+++ b/src/components/header/config.js
@@ -24,24 +24,14 @@ export default {
           label: 'Help Center',
           href: '/help/',
         },
-        /* // TODO: enable these 2 links when we have the real urls
-        {
-          label: 'Events',
-          href: '/events/',
-        },
-        {
-          label: 'FAQ',
-          href: '/faq/',
-        },
-        */
         {
           label: 'Grants & Opportunities',
           href: '/grants-and-fellowships/projects/',
         },
         {
           label: 'Contact Us',
-          onClick: () => [],
-          isContactModal: true,
+          extLink:
+            'https://globalnaturewatch.zendesk.com/hc/en-us/requests/new',
         },
       ],
     },


### PR DESCRIPTION
## Overview

The current Contact Us form on Flagship should be removed and replaced with a direct link to the new Zendesk form across all pages. This will allow non-developers (e.g. Jessica Immelman) to manage and edit the form directly without requiring front-end changes.

New form URL: https://globalnaturewatch.zendesk.com/hc/en-us/requests/new

Pages to update:

- https://www.globalforestwatch.org/ — footer
- https://www.globalforestwatch.org/dashboards/global/ — footer
- https://www.globalforestwatch.org/help/ — 2 places: footer and under the help tab
- https://www.globalforestwatch.org/about/ — 3 places: footer, "Email Us", and "Contact Us" below the About paragraph
- https://www.globalforestwatch.org/topics/biodiversity/#footer — footer
- https://www.globalforestwatch.org/blog/ — footer
- https://www.globalforestwatch.org/search/ — footer
- https://www.globalforestwatch.org/my-gfw/ — footer

### Acceptance Criteria

Remove the existing embedded Contact Us form from Flagship
Replace all Contact Us instances across the pages listed above with a link to the new Zendesk form



